### PR TITLE
switches trigger action to on release publish

### DIFF
--- a/.github/workflows/ftp-upload.yml
+++ b/.github/workflows/ftp-upload.yml
@@ -1,8 +1,7 @@
 name: Github Pages Deploy
 on:
-  push:
-    branches:
-      - dev
+  release:
+    types: [published]
       
 jobs:
   uploadFTP:


### PR DESCRIPTION
https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#release

We want to trigger an FTP of the gh-pages branch to a server folder upon publication of a new release created at https://github.com/lightandluck/EEW-Website/releases